### PR TITLE
Handle `CdReadUnsupported` error

### DIFF
--- a/riprip_core/src/cdio.rs
+++ b/riprip_core/src/cdio.rs
@@ -602,8 +602,8 @@ impl LibcdioInstance {
 
 		match res {
 			driver_return_code_t_DRIVER_OP_NOT_PERMITTED => Err(RipRipError::CdReadNotPermitted),
-			driver_return_code_t_DRIVER_OP_UNSUPPORTED => Err(RipRipError::CdReadUnsupported),
 			driver_return_code_t_DRIVER_OP_SUCCESS => Ok(()),
+			driver_return_code_t_DRIVER_OP_UNSUPPORTED => Err(RipRipError::CdReadUnsupported),
 			_ => {
 				SHITLIST.with(|q| q.borrow_mut().insert(lsn));
 				Err(RipRipError::CdRead)

--- a/riprip_core/src/cdio.rs
+++ b/riprip_core/src/cdio.rs
@@ -28,6 +28,7 @@ use libcdio_sys::{
 	driver_id_t_DRIVER_DEVICE, // The equivalent of "use whatever's best".
 	driver_return_code_t_DRIVER_OP_NOT_PERMITTED,
 	driver_return_code_t_DRIVER_OP_SUCCESS,
+	driver_return_code_t_DRIVER_OP_UNSUPPORTED,
 	track_format_t_TRACK_FORMAT_AUDIO,
 	track_format_t_TRACK_FORMAT_ERROR,
 	track_format_t_TRACK_FORMAT_PSX,
@@ -600,7 +601,8 @@ impl LibcdioInstance {
 		};
 
 		match res {
-			driver_return_code_t_DRIVER_OP_NOT_PERMITTED => Err(RipRipError::CdReadUnsupported),
+			driver_return_code_t_DRIVER_OP_NOT_PERMITTED => Err(RipRipError::CdReadNotPermitted),
+			driver_return_code_t_DRIVER_OP_UNSUPPORTED => Err(RipRipError::CdReadUnsupported),
 			driver_return_code_t_DRIVER_OP_SUCCESS => Ok(()),
 			_ => {
 				SHITLIST.with(|q| q.borrow_mut().insert(lsn));

--- a/riprip_core/src/error.rs
+++ b/riprip_core/src/error.rs
@@ -145,6 +145,9 @@ pub enum RipRipError {
 	/// # CD read error.
 	CdRead,
 
+	/// # Operation not permitted.
+	CdReadNotPermitted,
+
 	/// # CD read operation terminal failure.
 	CdReadUnsupported,
 
@@ -246,7 +249,8 @@ impl fmt::Display for RipRipError {
 			Self::Cache => f.write_str("Unable to establish a cache directory."),
 			Self::CachePath(s) => write!(f, "Invalid cache path {s}."),
 			Self::CdRead => f.write_str("Read error."),
-			Self::CdReadUnsupported => f.write_str("Unable to read CD; settings are probably wrong."),
+			Self::CdReadNotPermitted => f.write_str("Unable to read CD; settings are probably wrong."),
+			Self::CdReadUnsupported => f.write_str("Unable to read CD; driver doesn't support a particular operation."),
 			Self::Cdtoc(s) => write!(f, "{s}"),
 			Self::Device(s) => write!(f, "Invalid device path {s}."),
 			Self::DeviceOpen(s) =>

--- a/riprip_core/src/error.rs
+++ b/riprip_core/src/error.rs
@@ -145,10 +145,10 @@ pub enum RipRipError {
 	/// # CD read error.
 	CdRead,
 
-	/// # Operation not permitted.
+	/// # CD read operation permission failure.
 	CdReadNotPermitted,
 
-	/// # CD read operation terminal failure.
+	/// # CD read operation support failure.
 	CdReadUnsupported,
 
 	/// # Invalid device.
@@ -249,8 +249,8 @@ impl fmt::Display for RipRipError {
 			Self::Cache => f.write_str("Unable to establish a cache directory."),
 			Self::CachePath(s) => write!(f, "Invalid cache path {s}."),
 			Self::CdRead => f.write_str("Read error."),
-			Self::CdReadNotPermitted => f.write_str("Unable to read CD; settings are probably wrong."),
-			Self::CdReadUnsupported => f.write_str("Unable to read CD; driver doesn't support a particular operation."),
+			Self::CdReadNotPermitted => f.write_str("Unable to read CD; operation not permitted."),
+			Self::CdReadUnsupported => f.write_str("Unable to read CD; operation unsupported (driver)."),
 			Self::Cdtoc(s) => write!(f, "{s}"),
 			Self::Device(s) => write!(f, "Invalid device path {s}."),
 			Self::DeviceOpen(s) =>


### PR DESCRIPTION
We want to explicitly match this error, particularly because on macOS, `libcdio` returns `DRIVER_OP_UNSUPPORTED` (error code -2).

https://github.com/libcdio/libcdio/blob/6fab4af6b907b36e8be63c1c289aa9ca4b3bd702/lib/driver/osx.c#L434

**Root Cause**: `GET_SCSI_FIXED` is not defined in the build configuration, so `get_scsi()` is completely skipped during initialization.

My understanding is that this macro is intentionally undefined on modern versions because Apple has progressively restricted raw SCSI pass-through functionality due to security concerns. Executing raw `SCSITask` operations often requires specialized code-signing entitlements that are unavailable to standard desktop applications.

Without those entitlements, the operating system may reject the request or terminate the connection, making this code path unreliable in typical application environments.

If we correctly handle unsupported error we will get:

```console
riprip$ export BINDGEN_EXTRA_CLANG_ARGS="-I/opt/homebrew/include"
export CFLAGS="-I/opt/homebrew/include"
export LDFLAGS="-L/opt/homebrew/lib"
export PKG_CONFIG_PATH="/opt/homebrew/opt/libcdio/lib/pkgconfig"
riprip$ cargo build -r
   Compiling aws-lc-sys v0.41.0
   Compiling bindgen v0.72.1
   Compiling libcdio-sys v2.0.0
   Compiling aws-lc-rs v1.17.0
   Compiling rustls v0.23.40
   Compiling rustls-webpki v0.103.13
   Compiling minreq v3.0.0-rc.1
   Compiling riprip_core v0.5.8 (/Users/elmattic/Code/riprip/riprip_core)
   Compiling riprip v0.5.8 (/Users/elmattic/Code/riprip/riprip)
    Finished `release` profile [optimized] target(s) in 25.76s
riprip$ ./target/release/riprip 
-------------------
HL-DT-STBD-RE BU40N
-------------------

CDTOC:       B+96+5BA1+93FA+E8E3+12700+1594A+1910F+1C543+1F868+23604+27685+2CD1A
AccurateRip: 011-00111ab3-0091729b-85098d0b
CDDB:        85098d0b
CUETools:    3RMOfxdwLDS74jUaQuvjxQkPfiE-
MusicBrainz: axhCAPv9uDJHxK1BdMkF3j2GmO0-

NO   FIRST    LAST  LENGTH          
----------------------------------------
01       0   23306   23307              
02   23307   37731   14425              
03   37732   59468   21737              
04   59469   75369   15901              
05   75370   88243   12874              
06   88244  102520   14277              
07  102521  115884   13364              
08  115885  128977   13093              
09  128978  144749   15772              
10  144750  161262   16513              
11  161263  183427   22165              
AA  183428                      LEAD-OUT
----------------------------------------


Rip Rip…
  Tracks:       1..=11
  Read Offset:  6
  Cache Bust:   Disabled
  Verification: AccurateRip/CTDB cf. 3+
                C2 Error Pointers (Sample)
                Re-Read Consistency 2+
                Re-Read Contention 2×
                Subchannel Sync
  Rip Passes:   1
  Read Order:   Normal
  Verbose:      No
  Destination:  ./_riprip/85098d0b_##.wav
…Hooray? [Y/n] Y


Error: Unable to read CD; driver doesn't support a particular operation.
```