### PR TITLE
Add a separate trait for the constructor

### DIFF
--- a/riprip_core/src/disc.rs
+++ b/riprip_core/src/disc.rs
@@ -14,6 +14,7 @@ use crate::{
 	CD_LEADOUT_LABEL,
 	CddaDriver,
 	CddaDriverExt,
+	CddaDriverNewExt,
 	cdtext::{
 		CDText,
 		CDTextError,

--- a/riprip_core/src/drivers/libcdio.rs
+++ b/riprip_core/src/drivers/libcdio.rs
@@ -10,6 +10,7 @@ use crate::{
 	Barcode,
 	CD_LEADIN,
 	CddaDriverExt,
+	CddaDriverNewExt,
 	DriveVendorModel,
 	macros::log,
 	RipRipError,
@@ -73,7 +74,7 @@ impl Drop for LibcdioInstance {
 	}
 }
 
-impl CddaDriverExt for LibcdioInstance {
+impl CddaDriverNewExt for LibcdioInstance {
 	#[expect(unsafe_code, reason = "For FFI.")]
 	/// # New!
 	fn new<P>(dev: Option<P>) -> Result<Self, RipRipError>
@@ -122,7 +123,9 @@ impl CddaDriverExt for LibcdioInstance {
 			Ok(out)
 		}
 	}
+}
 
+impl CddaDriverExt for LibcdioInstance {
 	#[expect(unsafe_code, reason = "For FFI.")]
 	/// # First Track Number.
 	fn first_track_num(&self) -> Result<u8, RipRipError> {

--- a/riprip_core/src/drivers/mod.rs
+++ b/riprip_core/src/drivers/mod.rs
@@ -75,17 +75,6 @@ thread_local! {
 ///
 /// This trait is used to help deduplicate code between drivers.
 pub(crate) trait CddaDriverExt: Sized {
-	/// # New!
-	///
-	/// Initialize a new instance, optionally connecting to a specific device.
-	///
-	/// ## Errors
-	///
-	/// This will return an error if initialization fails, or if the provided
-	/// device path is obviously wrong.
-	fn new<P>(dev: Option<P>) -> Result<Self, RipRipError>
-	where P: AsRef<Path>;
-
 	/// # First Track Number.
 	///
 	/// Return the first track number on the disc, almost always but not
@@ -265,6 +254,24 @@ pub(crate) trait CddaDriverExt: Sized {
 		// As good as we can do!
 		Ok(())
 	}
+}
+
+
+
+/// # CDDA Construction Trait.
+///
+/// This trait provides driver construction.
+pub(crate) trait CddaDriverNewExt: Sized {
+	/// # New!
+	///
+	/// Initialize a new instance, optionally connecting to a specific device.
+	///
+	/// ## Errors
+	///
+	/// This will return an error if initialization fails, or if the provided
+	/// device path is obviously wrong.
+	fn new<P>(dev: Option<P>) -> Result<Self, RipRipError>
+	where P: AsRef<Path>;
 }
 
 

--- a/riprip_core/src/lib.rs
+++ b/riprip_core/src/lib.rs
@@ -102,6 +102,7 @@ use chk::{
 use drivers::{
 	CddaDriver,
 	CddaDriverExt,
+	CddaDriverNewExt,
 };
 use rip::{
 	buf::RipBuffer,


### PR DESCRIPTION
This will help reduce code duplication across all low-level MMC-based drivers (BOT, `/dev/sg`, etc).